### PR TITLE
Set default value of getMeta to true in sci_search function

### DIFF
--- a/supabase/functions/sci_search/index.ts
+++ b/supabase/functions/sci_search/index.ts
@@ -418,7 +418,7 @@ Deno.serve(async (req) => {
     }
   }
 
-  const { query, filter, datefilter, topK = 5, extK = 0, getMeta = false } = await req.json();
+  const { query, filter, datefilter, topK = 5, extK = 0, getMeta = true } = await req.json();
   // console.log(query, filter);
 
   logInsert(email, Date.now(), 'sci_search', topK, extK);


### PR DESCRIPTION
This pull request includes a small change to the `supabase/functions/sci_search/index.ts` file. The change modifies the default value of the `getMeta` parameter from `false` to `true`.

* [`supabase/functions/sci_search/index.ts`](diffhunk://#diff-11d79a7e388a9e562618ad93a1a5664379d2a43130d757f2f86d86dd51f72edbL421-R421): Changed the default value of `getMeta` to `true` in the `Deno.serve` function.