### PR TITLE
docs: add docpact governance docs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -12,6 +12,7 @@ routing:
       paths:
         - AGENTS.md
         - .docpact/**
+        - .github/workflows/docpact.yml
         - _docs/**
     architecture:
       paths:
@@ -34,6 +35,7 @@ coverage:
     - AGENTS.md
     - README.md
     - .docpact/**
+    - .github/workflows/docpact.yml
     - _docs/**
     - package.json
     - deno.json
@@ -83,6 +85,8 @@ rules:
         kind: agent-contract
       - path: .docpact/config.yaml
         kind: machine-contract
+      - path: .github/workflows/docpact.yml
+        kind: governance-ci
       - path: _docs/**
         kind: governed-docs
       - path: README.md

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,0 +1,147 @@
+version: 1
+layout: repo
+lastReviewedAt: "2026-04-29"
+lastReviewedCommit: "6769a7b7210a6386d6dae6695bdd9010a1185614"
+
+repo:
+  id: edge-function
+
+routing:
+  intents:
+    governance:
+      paths:
+        - AGENTS.md
+        - .docpact/**
+        - _docs/**
+    architecture:
+      paths:
+        - supabase/functions/**
+        - supabase/config.toml
+        - supabase/seed.sql
+        - scripts/**
+    operations:
+      paths:
+        - README.md
+        - package.json
+        - deno.json
+        - Dockerfile
+        - .env.example
+        - supabase/.env.example
+        - test.example.http
+
+coverage:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/**
+    - _docs/**
+    - package.json
+    - deno.json
+    - Dockerfile
+    - .env.example
+    - supabase/.env.example
+    - supabase/config.toml
+    - supabase/seed.sql
+    - supabase/functions/**
+    - scripts/**
+    - test.example.http
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+    - .DS_Store
+    - "**/.DS_Store"
+
+docInventory:
+  include:
+    - AGENTS.md
+    - README.md
+    - .docpact/config.yaml
+    - _docs/**
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+
+freshness:
+  warn_after_commits: 50
+  warn_after_days: 90
+  critical_after_days: 180
+
+rules:
+  - id: edge-function-governance
+    scope: repo
+    repo: edge-function
+    triggers:
+      - path: AGENTS.md
+        kind: agent-contract
+      - path: .docpact/config.yaml
+        kind: machine-contract
+      - path: _docs/**
+        kind: governed-docs
+      - path: README.md
+        kind: repo-entry
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: _docs/README.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/standards/documentation-standards.md
+        mode: review_or_update
+    reason: Repository entry guidance, governance config, and documentation standards must remain aligned.
+  - id: edge-function-api-surface
+    scope: repo
+    repo: edge-function
+    triggers:
+      - path: supabase/functions/**
+        kind: edge-function-source
+      - path: supabase/config.toml
+        kind: supabase-config
+      - path: supabase/seed.sql
+        kind: database-seed
+      - path: scripts/**
+        kind: support-script
+    requiredDocs:
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+    reason: Edge function behavior, Supabase configuration, and support scripts must stay synchronized with architecture and operations docs.
+  - id: edge-function-operations
+    scope: repo
+    repo: edge-function
+    triggers:
+      - path: package.json
+        kind: node-workflow
+      - path: deno.json
+        kind: deno-workflow
+      - path: Dockerfile
+        kind: deployment-container
+      - path: .env.example
+        kind: environment-template
+      - path: supabase/.env.example
+        kind: environment-template
+      - path: test.example.http
+        kind: api-test-example
+    requiredDocs:
+      - path: README.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+    reason: Runtime commands, environment templates, deployment packaging, and test examples define operator-facing behavior.

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -1,0 +1,40 @@
+name: docpact
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            validate-config
+            --root .
+            --strict
+
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            lint
+            --root .
+            --base ${{ github.event.pull_request.base.sha }}
+            --head ${{ github.sha }}
+            --mode enforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+---
+docType: agent-contract
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "Before editing the edge-function repository."
+whenToUpdate: "When repo entry points, workflow commands, docpact config, deployment boundaries, or service ownership change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# TianGong AI Edge Function Agent Contract
+
+This repository owns the Supabase Edge Function surface for TianGong AI search
+and generation APIs. Workspace-level submodule policy remains in the root
+workspace; product implementation and repo-local documentation belong here.
+
+## Required Load Order
+
+1. Read this file.
+2. Read `.docpact/config.yaml`.
+3. Run `docpact route --root . --paths <target-paths> --format json` from this
+   repo root for the files you plan to change.
+4. Read the relevant files under `_docs/contracts/**`, `_docs/architecture/**`,
+   and `_docs/runbooks/**`.
+5. Read the implementation files under `supabase/functions/**` or `scripts/**`.
+
+## Source Of Truth
+
+- `.docpact/config.yaml`: machine-readable governance rules, routing aliases,
+  coverage, document inventory, and freshness policy.
+- `README.md`: developer setup, local Supabase serving, Docker, and remote
+  deployment command examples.
+- `_docs/contracts/repo-contract.md`: durable ownership and boundary rules.
+- `_docs/architecture/repo-architecture.md`: current service topology and key
+  paths.
+- `_docs/runbooks/development.md`: repeatable local development and validation
+  steps.
+
+## Hard Boundaries
+
+- Do not move workspace submodule policy, branch policy, or integration
+  completion rules into this repository.
+- Do not commit local secrets from `.env.local`, `supabase/.env.local`, or
+  production Supabase secrets.
+- Treat each top-level function directory under `supabase/functions/`, excluding
+  `_shared/`, as an API surface; update API or architecture docs when behavior,
+  parameters, auth, response shape, deployed names, or target indexes change.
+
+## Completion Criteria
+
+- Relevant docpact route output has been reviewed before code or docs changes.
+- Docs touched by the route result are reviewed or updated.
+- `docpact validate-config --root . --strict` passes after governance changes.
+- For implementation changes, run the repo's relevant validation command from
+  `README.md` or `_docs/runbooks/development.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repo entry points, workflow commands, docpact config, deploy
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When setting up, serving, testing, or deploying TianGong AI Edge Functions."
+whenToUpdate: "When local setup, runtime commands, environment templates, deployment steps, or exposed functions change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - package.json
+  - deno.json
+  - Dockerfile
+  - .env.example
+  - supabase/**
+  - test.example.http
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
 # TianGong-AI-Edge-Functions
 
-## Env Preparing (Docker Engine MUST be Running)
+## Env Preparing
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
@@ -29,7 +51,8 @@ npm run lint
 deno info
 ```
 
-Rename the `.env.example` to `.env.local` and fill in the the values before the `npx supabase start` command.
+Copy `.env.example` to `.env.local` for root-level tooling, and copy
+`supabase/.env.example` to `supabase/.env.local` before running `npm start`.
 
 ## Local Development
 
@@ -64,6 +87,10 @@ Edit .env file refer to .env.example then use REST Client extension of VSCode to
 
 ## Docker Deployment on AWS ECS Fargate
 
+This path is not currently validated: `Dockerfile` references
+`supabase/functions/main` and `supabase/functions/import_map.json`, which are
+not present.
+
 ```bash
 docker build -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/supabase/edge-runtime:v20240715 .
 
@@ -95,6 +122,8 @@ npx supabase functions deploy report_search --project-ref qyyqlnwqwgvzxnccnbgm -
 npx supabase functions deploy standard_search --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
 npx supabase functions deploy textbook_search --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
 npx supabase functions deploy green_deal_search --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
+npx supabase functions deploy bigquery_search --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
+npx supabase functions deploy info_extract --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
 
 npx supabase functions deploy question_generation --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt
 npx supabase functions deploy kg_generate --project-ref qyyqlnwqwgvzxnccnbgm --no-verify-jwt

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -1,0 +1,36 @@
+---
+docType: index
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When navigating edge-function repository documentation."
+whenToUpdate: "When repository documentation layers, key docs, or governance routing change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# Edge Function Documentation
+
+This directory contains the repo-local source documents governed by docpact.
+
+## Layers
+
+- Layer 0: `AGENTS.md` for mandatory agent entry guidance.
+- Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- Layer 2: current contracts, architecture, standards, and runbooks under
+  `_docs/**`.
+
+## Current Documents
+
+- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and
+  completion rules.
+- `_docs/architecture/repo-architecture.md`: Supabase Edge Function topology.
+- `_docs/runbooks/development.md`: local development, validation, and deployment
+  workflow.
+- `_docs/standards/documentation-standards.md`: repo-local documentation rules.

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repository documentation layers, key docs, or governance rou
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
@@ -23,6 +24,8 @@ This directory contains the repo-local source documents governed by docpact.
 
 - Layer 0: `AGENTS.md` for mandatory agent entry guidance.
 - Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- CI: `.github/workflows/docpact.yml` for config validation and PR
+  documentation lint.
 - Layer 2: current contracts, architecture, standards, and runbooks under
   `_docs/**`.
 

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -1,0 +1,53 @@
+---
+docType: architecture
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When changing Supabase Edge Functions, support scripts, or deployment packaging."
+whenToUpdate: "When function topology, shared utilities, deployment targets, or runtime assumptions change."
+checkPaths:
+  - supabase/functions/**
+  - supabase/config.toml
+  - Dockerfile
+  - package.json
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# Edge Function Architecture
+
+## Overview
+
+The repository packages Supabase Edge Functions for TianGong AI search and
+generation APIs. Local development is driven by the Supabase CLI through
+`npm start`, which serves functions with `supabase/.env.local`.
+
+## Key Paths
+
+- `supabase/functions/_shared/**`: shared function utilities.
+- `supabase/functions/*_search/**`: search endpoints, including ESG, science,
+  education, reports, standards, patents, textbooks, Green Deal, internal
+  content, and BigQuery-backed search.
+- `supabase/functions/info_extract/**`: information extraction endpoint.
+- `supabase/functions/question_generation/**`: question generation endpoint.
+- `supabase/functions/kg_generate/**`: knowledge graph generation endpoint.
+- `supabase/config.toml`: local Supabase project configuration.
+- `scripts/eval_search_quality.ts`: search quality evaluation helper.
+- `Dockerfile`: unvalidated container packaging; it currently references
+  missing `supabase/functions/main` and `supabase/functions/import_map.json`.
+
+## Runtime Shape
+
+The repo uses Node.js tooling for local commands, Deno for Supabase function
+runtime behavior, and the Supabase CLI for serving and deployment. Function
+environment values are derived from `.env.example` and `supabase/.env.example`;
+real local and production secrets must not be committed.
+
+## Integration Points
+
+- MCP server calls these edge functions through configured Supabase deployment
+  URLs.
+- KB and unstructure repositories produce or maintain data that these functions
+  query, but this repo only owns the API execution surface.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -1,0 +1,53 @@
+---
+docType: contract
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When deciding whether a change belongs in the edge-function repository."
+whenToUpdate: "When ownership, service boundaries, public API expectations, or completion criteria change."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - .docpact/config.yaml
+  - supabase/functions/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# Edge Function Repository Contract
+
+## Ownership
+
+This repository owns the Supabase Edge Functions used by TianGong AI search and
+generation surfaces. It also owns repo-local scripts, runtime command metadata,
+and environment templates needed to develop or deploy those functions.
+
+## Boundaries
+
+- Root workspace governance, branch policy, and submodule integration remain in
+  the workspace repository.
+- MCP client behavior belongs in the MCP repository unless a change requires a
+  backing edge function contract change here.
+- Knowledge-base ingestion or document processing logic belongs in the KB or
+  unstructure repositories unless it is packaged as an edge function in this
+  repository.
+
+## API Surface
+
+The public function directories under `supabase/functions/**` are treated as
+API surfaces. Changes to request parameters, authentication behavior, target
+indexes, response shape, or deployed function names require review of:
+
+- `README.md`
+- `_docs/architecture/repo-architecture.md`
+- `_docs/runbooks/development.md`
+
+## Completion Criteria
+
+- Run `docpact route` before editing governed files.
+- Run `docpact validate-config --root . --strict` after governance changes.
+- For function changes, run the relevant local Supabase serve or API test flow
+  described in `_docs/runbooks/development.md`.
+- Do not leave deployment, API, or validation facts only in chat.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -1,0 +1,63 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When developing, validating, or deploying edge functions."
+whenToUpdate: "When setup commands, local serve flow, validation, or deployment commands change."
+checkPaths:
+  - README.md
+  - package.json
+  - deno.json
+  - Dockerfile
+  - supabase/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# Edge Function Development Runbook
+
+## Setup
+
+1. Use Node.js 22 from `.nvmrc`.
+2. Install Deno as described in `README.md`.
+3. Run `npm install`.
+4. Copy `.env.example` to `.env.local` for root-level tooling.
+5. Copy `supabase/.env.example` to `supabase/.env.local` before running
+   `npm start`.
+
+## Local Serve
+
+Run:
+
+```bash
+npm start
+```
+
+This serves Supabase functions with:
+
+```bash
+supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt
+```
+
+## Validation
+
+Run:
+
+```bash
+npm run lint
+docpact validate-config --root . --strict
+```
+
+Use `test.example.http` or a REST client for endpoint checks when function
+behavior changes.
+
+## Deployment
+
+Use the Supabase deployment commands in `README.md` for individual functions.
+Docker packaging is not currently a validated path: `Dockerfile` references
+`supabase/functions/main` and `supabase/functions/import_map.json`, which are
+not present. Fix and validate the Dockerfile before using Docker deployment
+commands.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -1,0 +1,37 @@
+---
+docType: standard
+scope: repo
+status: current
+authoritative: true
+owner: edge-function
+language: en
+whenToUse: "When creating, moving, or reviewing edge-function documentation."
+whenToUpdate: "When documentation layers, metadata rules, or source-of-truth boundaries change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
+---
+
+# Edge Function Documentation Standards
+
+## Layers
+
+- `AGENTS.md`: mandatory repo entry guidance for agents.
+- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
+  document inventory.
+- `_docs/contracts/**`: current constraints and ownership rules.
+- `_docs/architecture/**`: current service topology and integration facts.
+- `_docs/runbooks/**`: executable procedures.
+- `_docs/standards/**`: repo-local documentation and engineering standards.
+
+## Rules
+
+- Keep deterministic governance facts in `.docpact/config.yaml`.
+- Keep explanatory architecture, API, and workflow details in `_docs/**`.
+- Update docs when public function names, request parameters, auth behavior,
+  response shape, deployment commands, or required environment variables change.
+- Do not duplicate root workspace branch policy or submodule integration policy
+  in this repository.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -10,6 +10,7 @@ whenToUpdate: "When documentation layers, metadata rules, or source-of-truth bou
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
@@ -22,6 +23,8 @@ lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
 - `AGENTS.md`: mandatory repo entry guidance for agents.
 - `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
   document inventory.
+- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR
+  documentation lint.
 - `_docs/contracts/**`: current constraints and ownership rules.
 - `_docs/architecture/**`: current service topology and integration facts.
 - `_docs/runbooks/**`: executable procedures.


### PR DESCRIPTION
Closes: N/A

## Summary
- Add repo-local docpact config, agent contract, and governed documentation structure.
- Align README/setup guidance with actual Supabase env and deployment constraints.

## Key Decisions
- Keep deterministic governance in .docpact/config.yaml and explanatory guidance in _docs/**.
- Document Docker packaging as unvalidated until missing Dockerfile paths are fixed.

## Validation
- docpact validate-config --root tiangong-ai-edge-function --strict --format json
- docpact coverage --root tiangong-ai-edge-function --format json
- docpact lint --root tiangong-ai-edge-function --files AGENTS.md,README.md,.docpact/config.yaml,_docs/README.md,_docs/architecture/repo-architecture.md,_docs/runbooks/development.md,_docs/contracts/repo-contract.md,_docs/standards/documentation-standards.md --format json

## Risks / Rollback
- Documentation-only change; rollback by reverting this PR.

## Follow-ups
- Validate or repair Docker packaging before advertising Docker deployment as supported.

## Workspace Integration
- Requires root workspace submodule pin update after merge.