### PR TITLE
[codex] Align course search and add rewrite model eval

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "a0929d5a40efe3ccb4627551555e325a73801d73"
+lastReviewedAt: '2026-05-23'
+lastReviewedCommit: '23798e03c82dd26645517ff13f4f3a358daf0dcc'
 
 repo:
   id: edge-function
@@ -55,7 +55,7 @@ coverage:
     - build/**
     - coverage/**
     - .DS_Store
-    - "**/.DS_Store"
+    - '**/.DS_Store'
 
 docInventory:
   include:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,59 +5,46 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "Before editing the edge-function repository."
-whenToUpdate: "When repo entry points, workflow commands, docpact config, deployment boundaries, or service ownership change."
+whenToUse: 'Before editing the edge-function repository.'
+whenToUpdate: 'When repo entry points, workflow commands, docpact config, deployment boundaries, or service ownership change.'
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 23798e03c82dd26645517ff13f4f3a358daf0dcc
 ---
 
 # TianGong AI Edge Function Agent Contract
 
-This repository owns the Supabase Edge Function surface for TianGong AI search
-and generation APIs. Workspace-level submodule policy remains in the root
-workspace; product implementation and repo-local documentation belong here.
+This repository owns the Supabase Edge Function surface for TianGong AI search and generation APIs. Workspace-level submodule policy remains in the root workspace; product implementation and repo-local documentation belong here.
 
 ## Required Load Order
 
 1. Read this file.
 2. Read `.docpact/config.yaml`.
-3. Run `docpact route --root . --paths <target-paths> --format json` from this
-   repo root for the files you plan to change.
-4. Read the relevant files under `_docs/contracts/**`, `_docs/architecture/**`,
-   and `_docs/runbooks/**`.
+3. Run `docpact route --root . --paths <target-paths> --format json` from this repo root for the files you plan to change.
+4. Read the relevant files under `_docs/contracts/**`, `_docs/architecture/**`, and `_docs/runbooks/**`.
 5. Read the implementation files under `supabase/functions/**` or `scripts/**`.
 
 ## Source Of Truth
 
-- `.docpact/config.yaml`: machine-readable governance rules, routing aliases,
-  coverage, document inventory, and freshness policy.
-- `README.md`: developer setup, local Supabase serving, Docker, and remote
-  deployment command examples.
+- `.docpact/config.yaml`: machine-readable governance rules, routing aliases, coverage, document inventory, and freshness policy.
+- `README.md`: developer setup, local Supabase serving, Docker, and remote deployment command examples.
 - `_docs/contracts/repo-contract.md`: durable ownership and boundary rules.
-- `_docs/architecture/repo-architecture.md`: current service topology and key
-  paths.
-- `_docs/runbooks/development.md`: repeatable local development and validation
-  steps.
+- `_docs/architecture/repo-architecture.md`: current service topology and key paths.
+- `_docs/runbooks/development.md`: repeatable local development and validation steps.
 
 ## Hard Boundaries
 
-- Do not move workspace submodule policy, branch policy, or integration
-  completion rules into this repository.
-- Do not commit local secrets from `.env.local`, `supabase/.env.local`, or
-  production Supabase secrets.
-- Treat each top-level function directory under `supabase/functions/`, excluding
-  `_shared/`, as an API surface; update API or architecture docs when behavior,
-  parameters, auth, response shape, deployed names, or target indexes change.
+- Do not move workspace submodule policy, branch policy, or integration completion rules into this repository.
+- Do not commit local secrets from `.env.local`, `supabase/.env.local`, or production Supabase secrets.
+- Treat each top-level function directory under `supabase/functions/`, excluding `_shared/`, as an API surface; update API or architecture docs when behavior, parameters, auth, response shape, deployed names, or target indexes change.
 
 ## Completion Criteria
 
 - Relevant docpact route output has been reviewed before code or docs changes.
 - Docs touched by the route result are reviewed or updated.
 - `docpact validate-config --root . --strict` passes after governance changes.
-- For implementation changes, run the repo's relevant validation command from
-  `README.md` or `_docs/runbooks/development.md`.
+- For implementation changes, run the repo's relevant validation command from `README.md` or `_docs/runbooks/development.md`.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When setting up, serving, testing, or deploying TianGong AI Edge Functions."
-whenToUpdate: "When local setup, runtime commands, environment templates, deployment steps, or exposed functions change."
+whenToUse: 'When setting up, serving, testing, or deploying TianGong AI Edge Functions.'
+whenToUpdate: 'When local setup, runtime commands, environment templates, deployment steps, or exposed functions change.'
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
@@ -51,8 +51,7 @@ npm run lint
 deno info
 ```
 
-Copy `.env.example` to `.env.local` for root-level tooling, and copy
-`supabase/.env.example` to `supabase/.env.local` before running `npm start`.
+Copy `.env.example` to `.env.local` for root-level tooling, and copy `supabase/.env.example` to `supabase/.env.local` before running `npm start`.
 
 ## Local Development
 
@@ -85,11 +84,28 @@ npx supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt
 
 Edit .env file refer to .env.example then use REST Client extension of VSCode to test the API in test.local.http.
 
+## Query Rewrite Model Evaluation
+
+`scripts/eval_query_rewrite_models.ts` compares `OPENAI_CHAT_MODEL` candidates for query rewrite only. It reuses the production rewrite prompts and schemas, keeps `gpt-4.1-mini` as the baseline, and writes JSON plus Markdown reports under `/tmp/tiangong-eval` by default.
+
+```bash
+# Fast compatibility check across baseline and candidate models.
+set -a; . ./supabase/.env.local; set +a
+deno run --allow-env --allow-net --allow-read --allow-write \
+  --config supabase/functions/deno.json \
+  scripts/eval_query_rewrite_models.ts --dry-run
+
+# Full run: all bundled search queries, repeated three times per model.
+deno run --allow-env --allow-net --allow-read --allow-write \
+  --config supabase/functions/deno.json \
+  scripts/eval_query_rewrite_models.ts --include-optional
+```
+
+The script evaluates `gpt-4.1-nano`, `gpt-4o-mini`, and GPT-5 nano-family candidates with `reasoning.effort=none` when configured. It does not change the production `OPENAI_CHAT_MODEL`; use the report recommendation before making a separate config change.
+
 ## Docker Deployment on AWS ECS Fargate
 
-This path is not currently validated: `Dockerfile` references
-`supabase/functions/main` and `supabase/functions/import_map.json`, which are
-not present.
+This path is not currently validated: `Dockerfile` references `supabase/functions/main` and `supabase/functions/import_map.json`, which are not present.
 
 ```bash
 docker build -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/supabase/edge-runtime:v20240715 .

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -5,15 +5,15 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When navigating edge-function repository documentation."
-whenToUpdate: "When repository documentation layers, key docs, or governance routing change."
+whenToUse: 'When navigating edge-function repository documentation.'
+whenToUpdate: 'When repository documentation layers, key docs, or governance routing change.'
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 23798e03c82dd26645517ff13f4f3a358daf0dcc
 ---
 
 # Edge Function Documentation
@@ -24,16 +24,12 @@ This directory contains the repo-local source documents governed by docpact.
 
 - Layer 0: `AGENTS.md` for mandatory agent entry guidance.
 - Layer 1: `.docpact/config.yaml` for machine-readable governance.
-- CI: `.github/workflows/docpact.yml` for config validation and PR
-  documentation lint.
-- Layer 2: current contracts, architecture, standards, and runbooks under
-  `_docs/**`.
+- CI: `.github/workflows/docpact.yml` for config validation and PR documentation lint.
+- Layer 2: current contracts, architecture, standards, and runbooks under `_docs/**`.
 
 ## Current Documents
 
-- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and
-  completion rules.
+- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and completion rules.
 - `_docs/architecture/repo-architecture.md`: Supabase Edge Function topology.
-- `_docs/runbooks/development.md`: local development, validation, and deployment
-  workflow.
+- `_docs/runbooks/development.md`: local development, validation, and deployment workflow.
 - `_docs/standards/documentation-standards.md`: repo-local documentation rules.

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -5,8 +5,8 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When changing Supabase Edge Functions, support scripts, or deployment packaging."
-whenToUpdate: "When function topology, shared utilities, deployment targets, or runtime assumptions change."
+whenToUse: 'When changing Supabase Edge Functions, support scripts, or deployment packaging.'
+whenToUpdate: 'When function topology, shared utilities, deployment targets, or runtime assumptions change.'
 checkPaths:
   - supabase/functions/**
   - supabase/config.toml
@@ -20,34 +20,25 @@ lastReviewedCommit: 6769a7b7210a6386d6dae6695bdd9010a1185614
 
 ## Overview
 
-The repository packages Supabase Edge Functions for TianGong AI search and
-generation APIs. Local development is driven by the Supabase CLI through
-`npm start`, which serves functions with `supabase/.env.local`.
+The repository packages Supabase Edge Functions for TianGong AI search and generation APIs. Local development is driven by the Supabase CLI through `npm start`, which serves functions with `supabase/.env.local`.
 
 ## Key Paths
 
 - `supabase/functions/_shared/**`: shared function utilities.
-- `supabase/functions/*_search/**`: search endpoints, including ESG, science,
-  KB course, education, reports, standards, patents, textbooks, Green Deal,
-  internal content, and BigQuery-backed search.
+- `supabase/functions/*_search/**`: search endpoints, including ESG, science, KB course, education, reports, standards, patents, textbooks, Green Deal, internal content, and BigQuery-backed search.
 - `supabase/functions/info_extract/**`: information extraction endpoint.
 - `supabase/functions/question_generation/**`: question generation endpoint.
 - `supabase/functions/kg_generate/**`: knowledge graph generation endpoint.
 - `supabase/config.toml`: local Supabase project configuration.
 - `scripts/eval_search_quality.ts`: search quality evaluation helper.
-- `Dockerfile`: unvalidated container packaging; it currently references
-  missing `supabase/functions/main` and `supabase/functions/import_map.json`.
+- `scripts/eval_query_rewrite_models.ts`: non-production query rewrite model evaluation helper for comparing OpenAI chat model candidates against the `gpt-4.1-mini` baseline.
+- `Dockerfile`: unvalidated container packaging; it currently references missing `supabase/functions/main` and `supabase/functions/import_map.json`.
 
 ## Runtime Shape
 
-The repo uses Node.js tooling for local commands, Deno for Supabase function
-runtime behavior, and the Supabase CLI for serving and deployment. Function
-environment values are derived from `.env.example` and `supabase/.env.example`;
-real local and production secrets must not be committed.
+The repo uses Node.js tooling for local commands, Deno for Supabase function runtime behavior, and the Supabase CLI for serving and deployment. Function environment values are derived from `.env.example` and `supabase/.env.example`; real local and production secrets must not be committed.
 
 ## Integration Points
 
-- MCP server calls these edge functions through configured Supabase deployment
-  URLs.
-- KB and unstructure repositories produce or maintain data that these functions
-  query, but this repo only owns the API execution surface.
+- MCP server calls these edge functions through configured Supabase deployment URLs.
+- KB and unstructure repositories produce or maintain data that these functions query, but this repo only owns the API execution surface.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -5,40 +5,32 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When deciding whether a change belongs in the edge-function repository."
-whenToUpdate: "When ownership, service boundaries, public API expectations, or completion criteria change."
+whenToUse: 'When deciding whether a change belongs in the edge-function repository.'
+whenToUpdate: 'When ownership, service boundaries, public API expectations, or completion criteria change.'
 checkPaths:
   - AGENTS.md
   - README.md
   - .docpact/config.yaml
   - supabase/functions/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 23798e03c82dd26645517ff13f4f3a358daf0dcc
 ---
 
 # Edge Function Repository Contract
 
 ## Ownership
 
-This repository owns the Supabase Edge Functions used by TianGong AI search and
-generation surfaces. It also owns repo-local scripts, runtime command metadata,
-and environment templates needed to develop or deploy those functions.
+This repository owns the Supabase Edge Functions used by TianGong AI search and generation surfaces. It also owns repo-local scripts, runtime command metadata, and environment templates needed to develop or deploy those functions.
 
 ## Boundaries
 
-- Root workspace governance, branch policy, and submodule integration remain in
-  the workspace repository.
-- MCP client behavior belongs in the MCP repository unless a change requires a
-  backing edge function contract change here.
-- Knowledge-base ingestion or document processing logic belongs in the KB or
-  unstructure repositories unless it is packaged as an edge function in this
-  repository.
+- Root workspace governance, branch policy, and submodule integration remain in the workspace repository.
+- MCP client behavior belongs in the MCP repository unless a change requires a backing edge function contract change here.
+- Knowledge-base ingestion or document processing logic belongs in the KB or unstructure repositories unless it is packaged as an edge function in this repository.
 
 ## API Surface
 
-The public function directories under `supabase/functions/**` are treated as
-API surfaces. Changes to request parameters, authentication behavior, target
-indexes, response shape, or deployed function names require review of:
+The public function directories under `supabase/functions/**` are treated as API surfaces. Changes to request parameters, authentication behavior, target indexes, response shape, or deployed function names require review of:
 
 - `README.md`
 - `_docs/architecture/repo-architecture.md`
@@ -48,6 +40,5 @@ indexes, response shape, or deployed function names require review of:
 
 - Run `docpact route` before editing governed files.
 - Run `docpact validate-config --root . --strict` after governance changes.
-- For function changes, run the relevant local Supabase serve or API test flow
-  described in `_docs/runbooks/development.md`.
+- For function changes, run the relevant local Supabase serve or API test flow described in `_docs/runbooks/development.md`.
 - Do not leave deployment, API, or validation facts only in chat.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -5,8 +5,8 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When developing, validating, or deploying edge functions."
-whenToUpdate: "When setup commands, local serve flow, validation, or deployment commands change."
+whenToUse: 'When developing, validating, or deploying edge functions.'
+whenToUpdate: 'When setup commands, local serve flow, validation, or deployment commands change.'
 checkPaths:
   - README.md
   - package.json
@@ -25,8 +25,7 @@ lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
 2. Install Deno as described in `README.md`.
 3. Run `npm install`.
 4. Copy `.env.example` to `.env.local` for root-level tooling.
-5. Copy `supabase/.env.example` to `supabase/.env.local` before running
-   `npm start`.
+5. Copy `supabase/.env.example` to `supabase/.env.local` before running `npm start`.
 
 ## Local Serve
 
@@ -51,13 +50,21 @@ npm run lint
 docpact validate-config --root . --strict
 ```
 
-Use `test.example.http` or a REST client for endpoint checks when function
-behavior changes.
+Use `test.example.http` or a REST client for endpoint checks when function behavior changes.
+
+## Query Rewrite Model Evaluation
+
+Use `scripts/eval_query_rewrite_models.ts` when comparing OpenAI chat models for query rewrite behavior. The script reuses production rewrite prompts and schemas, compares candidates against `gpt-4.1-mini`, and writes reports to `/tmp/tiangong-eval` unless `--output-prefix` is provided.
+
+```bash
+set -a; . ./supabase/.env.local; set +a
+deno run --allow-env --allow-net --allow-read --allow-write \
+  --config supabase/functions/deno.json \
+  scripts/eval_query_rewrite_models.ts --dry-run
+```
+
+Use `--include-optional` for optional GPT-5 nano-family candidates and `--models=<id,id>` to restrict the matrix. The script only reports a suggested `OPENAI_CHAT_MODEL`; it does not mutate production configuration.
 
 ## Deployment
 
-Use the Supabase deployment commands in `README.md` for individual functions.
-Docker packaging is not currently a validated path: `Dockerfile` references
-`supabase/functions/main` and `supabase/functions/import_map.json`, which are
-not present. Fix and validate the Dockerfile before using Docker deployment
-commands.
+Use the Supabase deployment commands in `README.md` for individual functions. Docker packaging is not currently a validated path: `Dockerfile` references `supabase/functions/main` and `supabase/functions/import_map.json`, which are not present. Fix and validate the Dockerfile before using Docker deployment commands.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -5,15 +5,15 @@ status: current
 authoritative: true
 owner: edge-function
 language: en
-whenToUse: "When creating, moving, or reviewing edge-function documentation."
-whenToUpdate: "When documentation layers, metadata rules, or source-of-truth boundaries change."
+whenToUse: 'When creating, moving, or reviewing edge-function documentation.'
+whenToUpdate: 'When documentation layers, metadata rules, or source-of-truth boundaries change.'
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 23798e03c82dd26645517ff13f4f3a358daf0dcc
 ---
 
 # Edge Function Documentation Standards
@@ -21,10 +21,8 @@ lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
 ## Layers
 
 - `AGENTS.md`: mandatory repo entry guidance for agents.
-- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
-  document inventory.
-- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR
-  documentation lint.
+- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and document inventory.
+- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR documentation lint.
 - `_docs/contracts/**`: current constraints and ownership rules.
 - `_docs/architecture/**`: current service topology and integration facts.
 - `_docs/runbooks/**`: executable procedures.
@@ -34,7 +32,5 @@ lastReviewedCommit: a0929d5a40efe3ccb4627551555e325a73801d73
 
 - Keep deterministic governance facts in `.docpact/config.yaml`.
 - Keep explanatory architecture, API, and workflow details in `_docs/**`.
-- Update docs when public function names, request parameters, auth behavior,
-  response shape, deployment commands, or required environment variables change.
-- Do not duplicate root workspace branch policy or submodule integration policy
-  in this repository.
+- Update docs when public function names, request parameters, auth behavior, response shape, deployment commands, or required environment variables change.
+- Do not duplicate root workspace branch policy or submodule integration policy in this repository.

--- a/scripts/eval_query_rewrite_models.ts
+++ b/scripts/eval_query_rewrite_models.ts
@@ -1,0 +1,776 @@
+import { getOpenAIClient } from '../supabase/functions/_shared/openai_client.ts';
+import { runStructuredOpenAITask } from '../supabase/functions/_shared/openai_structured_task.ts';
+import {
+  buildEnglishQuerySystemPrompt,
+  buildMultilingualQuerySystemPrompt,
+  EnglishQueryPack,
+  EnglishQueryProfile,
+  englishQuerySchema,
+  englishQueryWithAliasesSchema,
+  MultilingualQueryProfile,
+  multilingualQuerySchema,
+  multilingualQueryWithAliasesSchema,
+  QueryPack,
+  sanitizeEnglishQueryPack,
+  sanitizeMultilingualQueryPack,
+} from '../supabase/functions/_shared/search_query_utils.ts';
+import { FUNCTION_SPECS, FunctionSpec } from './eval_search_quality.ts';
+
+type RewriteMode = 'multilingual' | 'english';
+type CandidateStatus = 'ok' | 'rejected' | 'incompatible';
+
+interface Candidate {
+  id: string;
+  model: string;
+  inputPricePerMillion: number;
+  outputPricePerMillion: number;
+  reasoningEffort?: 'none';
+  optional?: boolean;
+}
+
+interface RewriteSpec {
+  name: string;
+  mode: RewriteMode;
+  multilingualProfile?: MultilingualQueryProfile;
+  englishProfile?: EnglishQueryProfile;
+  queries: string[];
+}
+
+interface RewriteRun {
+  query: string;
+  ok: boolean;
+  sanitized?: QueryPack | EnglishQueryPack;
+  normalized?: string;
+  latencyMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  error?: string;
+}
+
+interface ModelEvaluation {
+  candidate: Candidate;
+  runs: RewriteRun[];
+  compatibilityError?: string;
+}
+
+interface ModelJudgment {
+  query: string;
+  candidate_score: number;
+  baseline_score: number;
+  winner: 'candidate' | 'baseline' | 'tie' | 'both_bad';
+  reason: string;
+}
+
+interface CandidateSummary {
+  id: string;
+  model: string;
+  status: CandidateStatus;
+  queries: number;
+  ok: number;
+  json_validity_rate: number;
+  schema_validity_rate: number;
+  avg_quality: number;
+  baseline_avg_quality: number;
+  p50_latency_ms: number;
+  p90_latency_ms: number;
+  p95_latency_ms: number;
+  total_cost_usd: number;
+  combined_score: number;
+  rejection_reasons: string[];
+}
+
+interface CliOptions {
+  dryRun: boolean;
+  limit: number | null;
+  repeats: number;
+  includeOptional: boolean;
+  judgeModel: string;
+  outputPrefix: string;
+  models: Set<string> | null;
+}
+
+const BASELINE_ID = 'gpt-4.1-mini';
+const DEFAULT_OUTPUT_PREFIX = `/tmp/tiangong-eval/query-rewrite-model-eval-${Date.now()}`;
+
+const CANDIDATES: Candidate[] = [
+  {
+    id: 'gpt-4.1-mini',
+    model: 'gpt-4.1-mini',
+    inputPricePerMillion: 0.4,
+    outputPricePerMillion: 1.6,
+  },
+  {
+    id: 'gpt-4.1-nano',
+    model: 'gpt-4.1-nano',
+    inputPricePerMillion: 0.1,
+    outputPricePerMillion: 0.4,
+  },
+  {
+    id: 'gpt-4o-mini',
+    model: 'gpt-4o-mini',
+    inputPricePerMillion: 0.15,
+    outputPricePerMillion: 0.6,
+  },
+  {
+    id: 'gpt-5-nano-none',
+    model: 'gpt-5-nano',
+    reasoningEffort: 'none',
+    inputPricePerMillion: 0.05,
+    outputPricePerMillion: 0.4,
+  },
+  {
+    id: 'gpt-5.4-nano-none',
+    model: 'gpt-5.4-nano',
+    reasoningEffort: 'none',
+    inputPricePerMillion: 0.2,
+    outputPricePerMillion: 1.25,
+    optional: true,
+  },
+];
+
+const COURSE_SPEC: RewriteSpec = {
+  name: 'course_search',
+  mode: 'multilingual',
+  queries: [
+    '知识组织是什么？',
+    '知识组织',
+    '清华校友会的可喻之义',
+    '大学科研服务组织',
+    '清华人文教育的发展脉络',
+    'What is knowledge organization in university research services?',
+    '清华文科复建和大学改革有什么关系？',
+    '清华周刊中的学生自治',
+    '新闻学院 思想亚洲 全球治理',
+    '隐性知识显性化在组织中的作用',
+    '教育学院研究生教育成果奖',
+    '清华人文大展 校园文化 学生工作',
+  ],
+};
+
+const REWRITE_SPEC_OVERRIDES: Record<
+  string,
+  Pick<RewriteSpec, 'mode' | 'multilingualProfile' | 'englishProfile'>
+> = {
+  sci_search: { mode: 'english' },
+  patent_search: { mode: 'english' },
+  green_deal_search: { mode: 'english', englishProfile: 'green_deal_regulatory' },
+  report_search: { mode: 'multilingual', multilingualProfile: 'report' },
+};
+
+const JUDGMENT_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    judgments: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          candidate_score: { type: 'integer', minimum: 0, maximum: 4 },
+          baseline_score: { type: 'integer', minimum: 0, maximum: 4 },
+          winner: {
+            type: 'string',
+            enum: ['candidate', 'baseline', 'tie', 'both_bad'],
+          },
+          reason: { type: 'string' },
+        },
+        required: ['query', 'candidate_score', 'baseline_score', 'winner', 'reason'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['judgments'],
+  additionalProperties: false,
+};
+
+function parseCliOptions(): CliOptions {
+  const args = new Set(Deno.args);
+  if (args.has('--help')) {
+    console.log(`Usage:
+  deno run --allow-env --allow-net --allow-read --allow-write --config supabase/functions/deno.json scripts/eval_query_rewrite_models.ts [options]
+
+Options:
+  --dry-run                  Run 5 total queries once per model and include optional candidates.
+  --limit=N                  Limit total source queries before repeats.
+  --repeats=N                Repeat each query N times. Default: 3.
+  --models=a,b               Candidate ids or model names to run. Must include gpt-4.1-mini.
+  --include-optional         Include optional candidates such as gpt-5.4-nano-none.
+  --judge-model=MODEL        LLM judge model. Default: gpt-4.1-mini.
+  --output-prefix=PATH       Report path prefix. Default: /tmp/tiangong-eval/query-rewrite-model-eval-<timestamp>.
+`);
+    Deno.exit(0);
+  }
+
+  const getValue = (name: string) => {
+    const prefix = `--${name}=`;
+    return Deno.args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  };
+
+  const dryRun = args.has('--dry-run');
+  const limitArg = getValue('limit');
+  const repeatsArg = getValue('repeats');
+  const modelsArg = getValue('models');
+
+  return {
+    dryRun,
+    limit: dryRun ? 5 : limitArg ? Number(limitArg) : null,
+    repeats: dryRun ? 1 : repeatsArg ? Number(repeatsArg) : 3,
+    includeOptional: args.has('--include-optional') || dryRun,
+    judgeModel: getValue('judge-model') ?? 'gpt-4.1-mini',
+    outputPrefix: getValue('output-prefix') ?? DEFAULT_OUTPUT_PREFIX,
+    models: modelsArg ? new Set(modelsArg.split(',').map((model) => model.trim())) : null,
+  };
+}
+
+function selectCandidates(options: CliOptions) {
+  return CANDIDATES.filter((candidate) => {
+    if (candidate.optional && !options.includeOptional) {
+      return false;
+    }
+    return (
+      !options.models || options.models.has(candidate.id) || options.models.has(candidate.model)
+    );
+  });
+}
+
+function toRewriteSpecs(): RewriteSpec[] {
+  const searchSpecs = FUNCTION_SPECS.filter((spec) => spec.kind === 'search').map(
+    (spec: FunctionSpec): RewriteSpec => ({
+      name: spec.name,
+      queries: spec.queries,
+      mode: REWRITE_SPEC_OVERRIDES[spec.name]?.mode ?? 'multilingual',
+      multilingualProfile: REWRITE_SPEC_OVERRIDES[spec.name]?.multilingualProfile,
+      englishProfile: REWRITE_SPEC_OVERRIDES[spec.name]?.englishProfile,
+    }),
+  );
+
+  return [...searchSpecs, COURSE_SPEC];
+}
+
+function applyQueryLimit(specs: RewriteSpec[], limit: number | null) {
+  if (!limit || !Number.isFinite(limit) || limit <= 0) {
+    return specs;
+  }
+
+  const flattened = specs.flatMap((spec) => spec.queries.map((query) => ({ spec, query })));
+  return flattened.slice(0, limit).reduce<RewriteSpec[]>((accumulator, item) => {
+    const existing = accumulator.find((spec) => spec.name === item.spec.name);
+    if (existing) {
+      existing.queries.push(item.query);
+    } else {
+      accumulator.push({ ...item.spec, queries: [item.query] });
+    }
+    return accumulator;
+  }, []);
+}
+
+function repeatSpecs(specs: RewriteSpec[], repeats: number) {
+  const safeRepeats = Number.isFinite(repeats) && repeats > 0 ? Math.floor(repeats) : 1;
+  return specs.map((spec) => ({
+    ...spec,
+    queries: Array.from({ length: safeRepeats }, () => spec.queries).flat(),
+  }));
+}
+
+function getRewriteRequest(spec: RewriteSpec, query: string) {
+  if (spec.mode === 'english') {
+    const profile = spec.englishProfile ?? 'default';
+    const useAliasSchema = profile !== 'default';
+    return {
+      schemaName: useAliasSchema
+        ? `english_query_pack_generation_${profile}`
+        : 'english_query_pack_generation',
+      schema: useAliasSchema ? englishQueryWithAliasesSchema : englishQuerySchema,
+      systemPrompt: buildEnglishQuerySystemPrompt({ profile }),
+      userPrompt: `Original query: ${query}`,
+      sanitize: (raw: unknown) => sanitizeEnglishQueryPack(raw as EnglishQueryPack, query),
+    };
+  }
+
+  const profile = spec.multilingualProfile ?? 'default';
+  const useAliasSchema = profile !== 'default';
+  return {
+    schemaName: useAliasSchema
+      ? `search_query_pack_generation_${profile}`
+      : 'search_query_pack_generation',
+    schema: useAliasSchema ? multilingualQueryWithAliasesSchema : multilingualQuerySchema,
+    systemPrompt: buildMultilingualQuerySystemPrompt({ profile }),
+    userPrompt: `Original query: ${query}`,
+    sanitize: (raw: unknown) => sanitizeMultilingualQueryPack(raw as QueryPack, query),
+  };
+}
+
+function extractOutputText(response: unknown) {
+  if (!response || typeof response !== 'object') {
+    return '';
+  }
+
+  const record = response as Record<string, unknown>;
+  if (typeof record.output_text === 'string' && record.output_text.trim()) {
+    return record.output_text.trim();
+  }
+
+  const output = record.output;
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      const content =
+        item && typeof item === 'object' ? (item as Record<string, unknown>).content : null;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      for (const part of content) {
+        if (
+          part &&
+          typeof part === 'object' &&
+          typeof (part as Record<string, unknown>).text === 'string'
+        ) {
+          return String((part as Record<string, unknown>).text).trim();
+        }
+      }
+    }
+  }
+
+  return '';
+}
+
+function stripCodeFence(text: string) {
+  const fenced = text.trim().match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced?.[1]?.trim() ?? text.trim();
+}
+
+function parseJsonText(text: string) {
+  const normalized = stripCodeFence(text);
+  try {
+    return JSON.parse(normalized);
+  } catch (_error) {
+    const objectStart = normalized.indexOf('{');
+    const objectEnd = normalized.lastIndexOf('}');
+    if (objectStart >= 0 && objectEnd > objectStart) {
+      return JSON.parse(normalized.slice(objectStart, objectEnd + 1));
+    }
+    throw new Error('OpenAI output is not valid JSON');
+  }
+}
+
+function readUsageTokens(response: unknown) {
+  const usage =
+    response && typeof response === 'object'
+      ? ((response as Record<string, unknown>).usage as Record<string, unknown> | undefined)
+      : undefined;
+
+  return {
+    inputTokens: Number(usage?.input_tokens ?? usage?.prompt_tokens ?? 0),
+    outputTokens: Number(usage?.output_tokens ?? usage?.completion_tokens ?? 0),
+  };
+}
+
+function estimateTokens(text: string) {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+async function runRewrite(
+  candidate: Candidate,
+  spec: RewriteSpec,
+  query: string,
+): Promise<RewriteRun> {
+  const startedAt = performance.now();
+  const request = getRewriteRequest(spec, query);
+
+  try {
+    const client = getOpenAIClient() as unknown as {
+      responses?: { create?: (args: unknown) => Promise<unknown> };
+    };
+    if (!client.responses?.create) {
+      throw new Error('OpenAI SDK missing responses.create');
+    }
+
+    const response = await client.responses.create({
+      model: candidate.model,
+      temperature: 0,
+      input: [
+        { role: 'system', content: request.systemPrompt },
+        { role: 'user', content: request.userPrompt },
+      ],
+      ...(candidate.reasoningEffort ? { reasoning: { effort: candidate.reasoningEffort } } : {}),
+      text: {
+        format: {
+          type: 'json_schema',
+          name: request.schemaName,
+          schema: request.schema,
+          strict: true,
+        },
+      },
+    });
+
+    const outputText = extractOutputText(response);
+    const raw = parseJsonText(outputText);
+    const sanitized = request.sanitize(raw);
+    const usage = readUsageTokens(response);
+    const inputTokens =
+      usage.inputTokens || estimateTokens(`${request.systemPrompt}\n${request.userPrompt}`);
+    const outputTokens = usage.outputTokens || estimateTokens(outputText);
+    const costUsd =
+      (inputTokens * candidate.inputPricePerMillion +
+        outputTokens * candidate.outputPricePerMillion) /
+      1_000_000;
+
+    return {
+      query,
+      ok: true,
+      sanitized,
+      normalized: JSON.stringify(sanitized),
+      latencyMs: Math.round(performance.now() - startedAt),
+      inputTokens,
+      outputTokens,
+      costUsd,
+    };
+  } catch (error) {
+    return {
+      query,
+      ok: false,
+      latencyMs: Math.round(performance.now() - startedAt),
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function evaluateCandidate(candidate: Candidate, specs: RewriteSpec[]) {
+  const runs: RewriteRun[] = [];
+
+  for (const spec of specs) {
+    for (const query of spec.queries) {
+      console.log(`[${candidate.id}] ${spec.name}: ${query}`);
+      runs.push(await runRewrite(candidate, spec, query));
+    }
+  }
+
+  const firstError = runs.find((run) => !run.ok)?.error;
+  return {
+    candidate,
+    runs,
+    compatibilityError: runs.every((run) => !run.ok) ? firstError : undefined,
+  } satisfies ModelEvaluation;
+}
+
+function toComparableRows(
+  baseline: ModelEvaluation,
+  candidate: ModelEvaluation,
+  specs: RewriteSpec[],
+) {
+  const rows: Array<{
+    function_name: string;
+    query: string;
+    baseline: string;
+    candidate: string;
+    candidate_error?: string;
+  }> = [];
+  let offset = 0;
+
+  for (const spec of specs) {
+    for (const query of spec.queries) {
+      const baselineRun = baseline.runs[offset];
+      const candidateRun = candidate.runs[offset];
+      rows.push({
+        function_name: spec.name,
+        query,
+        baseline: baselineRun?.normalized ?? baselineRun?.error ?? 'missing baseline',
+        candidate: candidateRun?.normalized ?? candidateRun?.error ?? 'missing candidate',
+        ...(candidateRun?.error ? { candidate_error: candidateRun.error } : {}),
+      });
+      offset += 1;
+    }
+  }
+
+  return rows;
+}
+
+async function judgeCandidate(
+  baseline: ModelEvaluation,
+  candidate: ModelEvaluation,
+  specs: RewriteSpec[],
+  judgeModel: string,
+) {
+  if (candidate.candidate.id === baseline.candidate.id || candidate.compatibilityError) {
+    return [];
+  }
+
+  const rows = toComparableRows(baseline, candidate, specs).filter((row) => !row.candidate_error);
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const raw = await runStructuredOpenAITask<{ judgments: ModelJudgment[] }>({
+    model: judgeModel,
+    schemaName: `query_rewrite_model_eval_${candidate.candidate.id.replaceAll('.', '_')}`,
+    schema: JUDGMENT_SCHEMA,
+    temperature: 0,
+    systemPrompt:
+      'You evaluate query rewrite outputs for retrieval. Compare CANDIDATE against BASELINE. Prefer outputs that preserve the original scope, keep named entities and constraints, avoid invented facts, avoid answer-like prose, and produce concise retrieval-ready phrases. Score each side from 0 to 4. Use winner=candidate only when candidate is clearly better, winner=baseline only when baseline is clearly better, tie when equivalent, and both_bad when both are poor.',
+    userPrompt: JSON.stringify(rows),
+  });
+
+  return raw.judgments;
+}
+
+function percentile(values: number[], p: number) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+function summarizeEvaluation(
+  evaluation: ModelEvaluation,
+  judgments: ModelJudgment[],
+  baselineAverageQuality: number,
+): CandidateSummary {
+  const okRuns = evaluation.runs.filter((run) => run.ok);
+  const jsonValidityRate =
+    evaluation.runs.length === 0 ? 0 : okRuns.length / evaluation.runs.length;
+  const avgQuality =
+    evaluation.candidate.id === BASELINE_ID
+      ? baselineAverageQuality
+      : judgments.length > 0
+        ? judgments.reduce((sum, item) => sum + item.candidate_score, 0) / judgments.length
+        : 0;
+  const baselineAvg =
+    judgments.length > 0
+      ? judgments.reduce((sum, item) => sum + item.baseline_score, 0) / judgments.length
+      : baselineAverageQuality;
+  const rejectionReasons: string[] = [];
+
+  if (evaluation.compatibilityError) {
+    rejectionReasons.push(`Compatibility failure: ${evaluation.compatibilityError}`);
+  }
+  if (jsonValidityRate < 1) {
+    rejectionReasons.push('JSON/schema validity below 100%.');
+  }
+  if (evaluation.candidate.id !== BASELINE_ID && avgQuality < baselineAvg * 0.95) {
+    rejectionReasons.push('Average quality is more than 5% below baseline.');
+  }
+
+  return {
+    id: evaluation.candidate.id,
+    model: evaluation.candidate.model,
+    status:
+      rejectionReasons.length === 0
+        ? 'ok'
+        : evaluation.compatibilityError
+          ? 'incompatible'
+          : 'rejected',
+    queries: evaluation.runs.length,
+    ok: okRuns.length,
+    json_validity_rate: Number(jsonValidityRate.toFixed(4)),
+    schema_validity_rate: Number(jsonValidityRate.toFixed(4)),
+    avg_quality: Number(avgQuality.toFixed(3)),
+    baseline_avg_quality: Number(baselineAvg.toFixed(3)),
+    p50_latency_ms: percentile(
+      okRuns.map((run) => run.latencyMs),
+      50,
+    ),
+    p90_latency_ms: percentile(
+      okRuns.map((run) => run.latencyMs),
+      90,
+    ),
+    p95_latency_ms: percentile(
+      okRuns.map((run) => run.latencyMs),
+      95,
+    ),
+    total_cost_usd: Number(okRuns.reduce((sum, run) => sum + run.costUsd, 0).toFixed(6)),
+    combined_score: 0,
+    rejection_reasons: rejectionReasons,
+  };
+}
+
+function applyCombinedScores(summaries: CandidateSummary[]) {
+  const eligible = summaries.filter((summary) => summary.status === 'ok');
+  const bestLatency = Math.min(...eligible.map((summary) => summary.p50_latency_ms || Infinity));
+  const bestCost = Math.min(...eligible.map((summary) => summary.total_cost_usd || Infinity));
+  const baselineQuality =
+    summaries.find((summary) => summary.id === BASELINE_ID)?.avg_quality ||
+    Math.max(...eligible.map((summary) => summary.avg_quality));
+
+  for (const summary of summaries) {
+    if (summary.status !== 'ok') {
+      summary.combined_score = 0;
+      continue;
+    }
+
+    const qualityScore =
+      baselineQuality > 0 ? Math.min(1.1, summary.avg_quality / baselineQuality) : 0;
+    const latencyScore =
+      summary.p50_latency_ms > 0 && Number.isFinite(bestLatency)
+        ? Math.min(1, bestLatency / summary.p50_latency_ms)
+        : 0;
+    const costScore =
+      summary.total_cost_usd > 0 && Number.isFinite(bestCost)
+        ? Math.min(1, bestCost / summary.total_cost_usd)
+        : 0;
+
+    summary.combined_score = Number(
+      (qualityScore * 0.5 + latencyScore * 0.25 + costScore * 0.25).toFixed(4),
+    );
+  }
+}
+
+function pickWinner(summaries: CandidateSummary[]) {
+  return summaries
+    .filter((summary) => summary.status === 'ok')
+    .sort((a, b) => {
+      if (b.combined_score !== a.combined_score) {
+        return b.combined_score - a.combined_score;
+      }
+      return a.total_cost_usd - b.total_cost_usd;
+    })[0];
+}
+
+function toMarkdown(report: {
+  generated_at: string;
+  specs: Array<{ name: string; queries: number; mode: RewriteMode }>;
+  summaries: CandidateSummary[];
+  winner?: CandidateSummary;
+  judgments: Record<string, ModelJudgment[]>;
+}) {
+  const table = [
+    '| Model | Status | Quality | Baseline | p50 ms | p95 ms | Cost USD | Score |',
+    '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...report.summaries.map(
+      (summary) =>
+        `| ${summary.id} | ${summary.status} | ${summary.avg_quality} | ${summary.baseline_avg_quality} | ${summary.p50_latency_ms} | ${summary.p95_latency_ms} | ${summary.total_cost_usd} | ${summary.combined_score} |`,
+    ),
+  ].join('\n');
+
+  const regressions = Object.entries(report.judgments)
+    .flatMap(([model, judgments]) =>
+      judgments
+        .filter((judgment) => judgment.winner === 'baseline')
+        .slice(0, 3)
+        .map((judgment) => `- ${model}: ${judgment.query} - ${judgment.reason}`),
+    )
+    .join('\n');
+
+  return `# Query Rewrite Model Evaluation
+
+Generated at: ${report.generated_at}
+
+Recommended model: ${report.winner?.id ?? 'none'}
+
+${table}
+
+## Coverage
+
+${report.specs.map((spec) => `- ${spec.name}: ${spec.queries} ${spec.mode} queries`).join('\n')}
+
+## Top Regressions
+
+${regressions || 'No candidate regressions recorded.'}
+
+## Notes
+
+- GPT-5-family candidates with \`reasoning.effort=none\` are evaluated by actual API compatibility. Incompatible models are rejected.
+- Production \`OPENAI_CHAT_MODEL\` is not changed by this script.
+`;
+}
+
+async function main() {
+  const options = parseCliOptions();
+  const candidates = selectCandidates(options);
+  if (!candidates.some((candidate) => candidate.id === BASELINE_ID)) {
+    throw new Error(`Candidate set must include baseline ${BASELINE_ID}.`);
+  }
+
+  const specs = repeatSpecs(applyQueryLimit(toRewriteSpecs(), options.limit), options.repeats);
+  const queryCount = specs.reduce((sum, spec) => sum + spec.queries.length, 0);
+  console.log(`Evaluating ${candidates.length} models over ${queryCount} rewrite requests.`);
+
+  const evaluations: ModelEvaluation[] = [];
+  for (const candidate of candidates) {
+    evaluations.push(await evaluateCandidate(candidate, specs));
+  }
+
+  const baseline = evaluations.find((evaluation) => evaluation.candidate.id === BASELINE_ID);
+  if (!baseline) {
+    throw new Error(`Missing baseline evaluation for ${BASELINE_ID}.`);
+  }
+
+  const judgments: Record<string, ModelJudgment[]> = {};
+  for (const evaluation of evaluations) {
+    judgments[evaluation.candidate.id] = await judgeCandidate(
+      baseline,
+      evaluation,
+      specs,
+      options.judgeModel,
+    );
+  }
+
+  const baselineAverageQuality = 4;
+  const summaries = evaluations.map((evaluation) =>
+    summarizeEvaluation(
+      evaluation,
+      judgments[evaluation.candidate.id] ?? [],
+      baselineAverageQuality,
+    ),
+  );
+  applyCombinedScores(summaries);
+  const winner = pickWinner(summaries);
+  const reportOptions = {
+    dryRun: options.dryRun,
+    limit: options.limit,
+    repeats: options.repeats,
+    includeOptional: options.includeOptional,
+    judgeModel: options.judgeModel,
+    outputPrefix: options.outputPrefix,
+    models: options.models ? [...options.models] : null,
+  };
+
+  const report = {
+    generated_at: new Date().toISOString(),
+    options: reportOptions,
+    specs: specs.map((spec) => ({
+      name: spec.name,
+      mode: spec.mode,
+      queries: spec.queries.length,
+    })),
+    candidates,
+    summaries,
+    winner,
+    judgments,
+    evaluations,
+    suggested_openai_chat_model: winner?.status === 'ok' ? winner.model : BASELINE_ID,
+    gpt5_reasoning_none_note:
+      'OpenAI Responses API docs state that reasoning.effort=none is supported for GPT-5.1 and later; this script records API compatibility for GPT-5-family candidates instead of assuming support.',
+  };
+
+  const slashIndex = options.outputPrefix.lastIndexOf('/');
+  const outputDir = slashIndex >= 0 ? options.outputPrefix.slice(0, slashIndex) || '/' : '.';
+  await Deno.mkdir(outputDir, { recursive: true });
+  const jsonPath = `${options.outputPrefix}.json`;
+  const markdownPath = `${options.outputPrefix}.md`;
+  await Deno.writeTextFile(jsonPath, JSON.stringify(report, null, 2));
+  await Deno.writeTextFile(markdownPath, toMarkdown(report));
+
+  console.log('\n=== Query rewrite model evaluation ===');
+  console.log(
+    JSON.stringify(
+      {
+        winner: winner?.id ?? null,
+        suggested_openai_chat_model: report.suggested_openai_chat_model,
+        summaries,
+        jsonPath,
+        markdownPath,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/eval_search_quality.ts
+++ b/scripts/eval_search_quality.ts
@@ -1,8 +1,8 @@
 import { runStructuredOpenAITask } from '../supabase/functions/_shared/openai_structured_task.ts';
 
-type FunctionKind = 'search' | 'graph_search' | 'graph_generate';
+export type FunctionKind = 'search' | 'graph_search' | 'graph_generate';
 
-interface FunctionSpec {
+export interface FunctionSpec {
   name: string;
   kind: FunctionKind;
   queries: string[];
@@ -73,7 +73,7 @@ const JUDGMENT_SCHEMA: Record<string, unknown> = {
   additionalProperties: false,
 };
 
-const FUNCTION_SPECS: FunctionSpec[] = [
+export const FUNCTION_SPECS: FunctionSpec[] = [
   {
     name: 'green_deal_search',
     kind: 'search',

--- a/supabase/functions/_shared/openai_structured.ts
+++ b/supabase/functions/_shared/openai_structured.ts
@@ -103,6 +103,7 @@ export interface OpenAIStructuredOptions {
   model?: string;
   temperature?: number;
   baseUrl?: string;
+  reasoningEffort?: string;
 }
 
 export interface OpenAIStructuredRequest {
@@ -134,6 +135,9 @@ export async function openaiStructuredOutput<T>(request: OpenAIStructuredRequest
         { role: 'system', content: request.systemPrompt },
         { role: 'user', content: request.userPrompt },
       ],
+      ...(request.options?.reasoningEffort
+        ? { reasoning: { effort: request.options.reasoningEffort } }
+        : {}),
       text: {
         format: {
           type: 'json_schema',

--- a/supabase/functions/_shared/openai_structured_task.ts
+++ b/supabase/functions/_shared/openai_structured_task.ts
@@ -5,10 +5,12 @@ export interface OpenAIStructuredTaskRequest {
   schema: Record<string, unknown>;
   systemPrompt: string;
   userPrompt: string;
+  model?: string;
   modelEnvName?: string;
   fallbackModel?: string;
   temperature?: number;
   baseUrl?: string;
+  reasoningEffort?: string;
 }
 
 export function resolveOpenAIChatModel(
@@ -20,7 +22,8 @@ export function resolveOpenAIChatModel(
 }
 
 export async function runStructuredOpenAITask<T>(request: OpenAIStructuredTaskRequest): Promise<T> {
-  const model = resolveOpenAIChatModel(request.modelEnvName, request.fallbackModel);
+  const model =
+    request.model ?? resolveOpenAIChatModel(request.modelEnvName, request.fallbackModel);
 
   return await openaiStructuredOutput<T>({
     schemaName: request.schemaName,
@@ -31,6 +34,7 @@ export async function runStructuredOpenAITask<T>(request: OpenAIStructuredTaskRe
       model,
       temperature: request.temperature ?? 0,
       baseUrl: request.baseUrl,
+      reasoningEffort: request.reasoningEffort,
     },
   });
 }

--- a/supabase/functions/course_search/index.ts
+++ b/supabase/functions/course_search/index.ts
@@ -9,7 +9,6 @@ import { createClient } from '@supabase/supabase-js@2';
 import { corsHeaders } from '../_shared/cors.ts';
 import decodeApiKey from '../_shared/decode_api_key.ts';
 import generateQuery from '../_shared/generate_query.ts';
-import { getOpenAIClient } from '../_shared/openai_client.ts';
 import { generateEmbedding } from '../_shared/openai_embedding.ts';
 import { buildLexicalQueryCandidates } from '../_shared/search_query_utils.ts';
 import logInsert from '../_shared/supabase_function_log.ts';
@@ -27,12 +26,7 @@ const opensearch_index_name = Deno.env.get('OPENSEARCH_COURSE_INDEX_NAME') ?? ''
 const supabase_url = Deno.env.get('REMOTE_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? '';
 const supabase_publishable_key =
   Deno.env.get('REMOTE_SUPABASE_PUBLISHABLE_KEY') ?? Deno.env.get('SUPABASE_PUBLISHABLE_KEY') ?? '';
-const supabase_service_role_key =
-  Deno.env.get('REMOTE_SUPABASE_SERVICE_ROLE_KEY') ??
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
-  Deno.env.get('REMOTE_SUPABASE_SECRET_KEY') ??
-  Deno.env.get('SUPABASE_SECRET_KEY') ??
-  '';
+const supabase_service_role_key = Deno.env.get('REMOTE_SUPABASE_SERVICE_ROLE_KEY') ?? '';
 
 const pc = new Pinecone({ apiKey: pinecone_api_key });
 
@@ -86,11 +80,16 @@ function getServiceSupabase() {
   return serviceSupabase;
 }
 
-type QueryMode = 'retrieve' | 'answer';
-type RewriteMode = 'auto' | 'off' | 'force';
-type PrimitiveFilterValue = string | number | boolean;
-type FilterTerms = Record<string, PrimitiveFilterValue[]>;
-type FilterRanges = Record<string, { gte?: number; lte?: number }>;
+type FilterType = { [field: string]: string[] };
+type DateFilterType = { [field: string]: { gte?: number; lte?: number } };
+type FiltersItem = {
+  terms?: FilterType;
+  range?: DateFilterType;
+};
+type FiltersType = FiltersItem[];
+type PCFilter = {
+  $and: Array<{ [field: string]: { $in?: string[]; $gte?: number; $lte?: number } }>;
+};
 
 interface SearchTarget {
   opensearchIndexName: string;
@@ -99,7 +98,6 @@ interface SearchTarget {
 }
 
 interface AuthContext {
-  actorId: string;
   subject: string;
   collectionScope: string[];
 }
@@ -117,10 +115,8 @@ interface CourseChunk {
 
 interface RequestBody {
   query: string;
-  mode: QueryMode;
-  rewrite: RewriteMode;
-  scope: Record<string, unknown>;
-  filters: Record<string, unknown>;
+  filter: FilterType;
+  datefilter: DateFilterType;
   topK: number;
   extK: number;
 }
@@ -142,7 +138,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 
 function requireServiceRoleKey() {
   if (!supabase_service_role_key) {
-    throw new Error('Missing REMOTE_SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_ROLE_KEY.');
+    throw new Error('Missing REMOTE_SUPABASE_SERVICE_ROLE_KEY.');
   }
 }
 
@@ -178,26 +174,6 @@ function normalizeNonNegativeInteger(rawValue: unknown, defaultValue: number, fi
   return value;
 }
 
-function normalizeMode(rawMode: unknown): QueryMode {
-  if (rawMode === undefined || rawMode === null || rawMode === '') {
-    return 'retrieve';
-  }
-  if (rawMode === 'retrieve' || rawMode === 'answer') {
-    return rawMode;
-  }
-  throw new RequestValidationError('`mode` must be "retrieve" or "answer".');
-}
-
-function normalizeRewrite(rawRewrite: unknown): RewriteMode {
-  if (rawRewrite === undefined || rawRewrite === null || rawRewrite === '') {
-    return 'auto';
-  }
-  if (rawRewrite === 'auto' || rawRewrite === 'off' || rawRewrite === 'force') {
-    return rawRewrite;
-  }
-  throw new RequestValidationError('`rewrite` must be "auto", "off", or "force".');
-}
-
 function normalizeObject(rawValue: unknown, fieldName: string): Record<string, unknown> {
   if (rawValue === undefined || rawValue === null) {
     return {};
@@ -211,10 +187,8 @@ function normalizeObject(rawValue: unknown, fieldName: string): Record<string, u
 function normalizeRequestBody(body: Record<string, unknown>): RequestBody {
   return {
     query: normalizeRequiredQuery(body.query),
-    mode: normalizeMode(body.mode),
-    rewrite: normalizeRewrite(body.rewrite),
-    scope: normalizeObject(body.scope, 'scope'),
-    filters: normalizeObject(body.filters ?? body.filter, 'filters'),
+    filter: normalizeFilter(normalizeObject(body.filter, 'filter')),
+    datefilter: normalizeDateFilter(body.datefilter),
     topK: normalizePositiveInteger(body.topK, 5, 'topK'),
     extK: normalizeNonNegativeInteger(body.extK, 0, 'extK'),
   };
@@ -241,16 +215,6 @@ function normalizeStringList(rawValue: unknown): string[] {
   return [...normalized.values()];
 }
 
-function normalizeUuidList(rawValue: unknown, fieldName: string): string[] {
-  const values = normalizeStringList(rawValue);
-  for (const value of values) {
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
-      throw new RequestValidationError(`\`${fieldName}\` must contain UUID values.`);
-    }
-  }
-  return values;
-}
-
 function normalizeCollectionPath(path: string): string {
   const normalized = path.trim().replace(/^\/+|\/+$/g, '');
   if (
@@ -263,54 +227,8 @@ function normalizeCollectionPath(path: string): string {
   return `/${normalized}`;
 }
 
-function normalizeCollectionPaths(rawValue: unknown): string[] {
-  return normalizeStringList(rawValue).map(normalizeCollectionPath);
-}
-
-function isPathWithin(path: string, scopePath: string) {
-  return path === scopePath || path.startsWith(`${scopePath}/`);
-}
-
-function intersectScopePaths(requestedPaths: string[], tokenScopePaths: string[]) {
-  if (tokenScopePaths.length === 0) {
-    return requestedPaths;
-  }
-  if (requestedPaths.length === 0) {
-    return tokenScopePaths;
-  }
-
-  const effective = new Set<string>();
-  for (const requestedPath of requestedPaths) {
-    for (const tokenPath of tokenScopePaths) {
-      if (isPathWithin(requestedPath, tokenPath)) {
-        effective.add(requestedPath);
-      } else if (isPathWithin(tokenPath, requestedPath)) {
-        effective.add(tokenPath);
-      }
-    }
-  }
-  return [...effective];
-}
-
 function collectionPathToTag(path: string) {
   return path.split('/').filter(Boolean).at(-1) ?? '';
-}
-
-function mergeScopeIntoFilters(
-  rawFilters: Record<string, unknown>,
-  scope: Record<string, unknown>,
-  collectionScope: string[],
-) {
-  const filters = { ...rawFilters };
-  const requestedPaths = normalizeCollectionPaths(scope.collection_path ?? scope.collection_paths);
-  const effectivePaths = intersectScopePaths(requestedPaths, collectionScope);
-  const scopeTags = effectivePaths.map(collectionPathToTag).filter(Boolean);
-
-  if (scopeTags.length > 0) {
-    filters.tags = [...normalizeStringList(filters.tags), ...scopeTags];
-  }
-
-  return filters;
 }
 
 function extractBearerToken(authorization: string | null) {
@@ -357,7 +275,6 @@ async function authenticateRequest(req: Request): Promise<AuthContext | Response
     }
 
     return {
-      actorId: String(row.actor_user_id),
       subject: String(row.client_id ?? row.actor_user_id),
       collectionScope: Array.isArray(row.collection_scope)
         ? row.collection_scope.map((path: unknown) => normalizeCollectionPath(String(path)))
@@ -391,7 +308,6 @@ async function authenticateRequest(req: Request): Promise<AuthContext | Response
   }
 
   return {
-    actorId: data.user.id,
     subject: email,
     collectionScope: [],
   };
@@ -422,133 +338,98 @@ function getIdRange(id: string, extK: number): Set<string> {
   return idRange;
 }
 
-function normalizePrimitiveFilterValue(value: unknown): PrimitiveFilterValue | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-  if (typeof value === 'string') {
-    const text = value.trim();
-    return text ? text : null;
-  }
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  return null;
-}
+function normalizeFilter(rawFilter: Record<string, unknown>): FilterType {
+  const filter: FilterType = {};
 
-function normalizeFilters(rawFilters: Record<string, unknown>) {
-  const allowedFilterFields = new Set(['tags', 'raw_relative_path', 'page_number']);
-  const terms: FilterTerms = {};
-  const range: FilterRanges = {};
-
-  for (const [field, rawValue] of Object.entries(rawFilters)) {
-    if (!allowedFilterFields.has(field)) {
-      throw new RequestValidationError(
-        `Unsupported filter field: ${field}. Supported fields: tags, raw_relative_path, page_number.`,
-      );
-    }
-
-    if (
-      field === 'page_number' &&
-      rawValue &&
-      typeof rawValue === 'object' &&
-      !Array.isArray(rawValue)
-    ) {
-      const rawRange = rawValue as Record<string, unknown>;
-      const pageRange: { gte?: number; lte?: number } = {};
-      for (const boundary of ['gte', 'lte'] as const) {
-        const boundaryValue = rawRange[boundary];
-        if (boundaryValue === undefined || boundaryValue === null || boundaryValue === '') {
-          continue;
-        }
-        const parsed = typeof boundaryValue === 'number' ? boundaryValue : Number(boundaryValue);
-        if (!Number.isFinite(parsed)) {
-          throw new RequestValidationError('`filters.page_number.gte/lte` must be numbers.');
-        }
-        pageRange[boundary] = parsed;
-      }
-      if (Object.keys(pageRange).length > 0) {
-        range[field] = pageRange;
-      }
-      continue;
-    }
-
-    const values = (Array.isArray(rawValue) ? rawValue : [rawValue])
-      .map(normalizePrimitiveFilterValue)
-      .filter((value): value is PrimitiveFilterValue => value !== null);
-
+  for (const [field, rawValue] of Object.entries(rawFilter)) {
+    const values = normalizeStringList(rawValue);
     if (values.length > 0) {
-      terms[field] = [
-        ...new Map(values.map((value) => [`${typeof value}:${String(value)}`, value])).values(),
-      ];
+      filter[field] = values;
     }
   }
 
-  return { terms, range };
+  return filter;
 }
 
-function buildOpenSearchFilter(filters: ReturnType<typeof normalizeFilters>) {
-  const clauses: Array<Record<string, unknown>> = [];
+function normalizeDateFilter(rawDatefilter: unknown): DateFilterType {
+  const rawFilter = normalizeObject(rawDatefilter, 'datefilter');
+  const datefilter: DateFilterType = {};
 
-  for (const [field, values] of Object.entries(filters.terms)) {
-    clauses.push({ terms: { [field]: values } });
+  for (const [field, rawValue] of Object.entries(rawFilter)) {
+    if (!rawValue || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
+      throw new RequestValidationError('`datefilter` values must be range objects.');
+    }
+
+    const rawRange = rawValue as Record<string, unknown>;
+    const range: { gte?: number; lte?: number } = {};
+    for (const boundary of ['gte', 'lte'] as const) {
+      const boundaryValue = rawRange[boundary];
+      if (boundaryValue === undefined || boundaryValue === null || boundaryValue === '') {
+        continue;
+      }
+      const parsed = typeof boundaryValue === 'number' ? boundaryValue : Number(boundaryValue);
+      if (!Number.isFinite(parsed)) {
+        throw new RequestValidationError('`datefilter` gte/lte values must be numbers.');
+      }
+      range[boundary] = parsed;
+    }
+
+    if (Object.keys(range).length > 0) {
+      datefilter[field] = range;
+    }
   }
 
-  for (const [field, value] of Object.entries(filters.range)) {
-    clauses.push({ range: { [field]: value } });
-  }
-
-  return clauses;
+  return datefilter;
 }
 
-function buildPineconeFilter(filters: ReturnType<typeof normalizeFilters>) {
-  const clauses: Array<Record<string, unknown>> = [];
-
-  for (const [field, values] of Object.entries(filters.terms)) {
-    clauses.push({ [field]: { $in: values } });
+function buildFilters(filter?: FilterType, datefilter?: DateFilterType): FiltersType {
+  const filters: FiltersType = [];
+  if (filter && Object.keys(filter).length > 0) {
+    filters.push({ terms: filter });
   }
-
-  for (const [field, value] of Object.entries(filters.range)) {
-    clauses.push({
-      [field]: {
-        ...(value.gte !== undefined ? { $gte: value.gte } : {}),
-        ...(value.lte !== undefined ? { $lte: value.lte } : {}),
-      },
-    });
+  if (datefilter && Object.keys(datefilter).length > 0) {
+    filters.push({ range: datefilter });
   }
-
-  return clauses.length > 0 ? { $and: clauses } : undefined;
+  return filters;
 }
 
-function shouldAutoRewrite(query: string) {
-  const trimmed = query.trim();
-  if (/^(doi|isbn|issn|patent|标准号)[:：]/i.test(trimmed)) {
-    return false;
-  }
-  if (/^[a-z0-9_\-./:]+$/i.test(trimmed) && trimmed.length <= 32) {
-    return false;
-  }
-  return trimmed.length > 12 || /[?？,，。;；\s]/u.test(trimmed);
-}
+function filterToPCQuery(filters: FiltersType): PCFilter | undefined {
+  const andConditions = filters.flatMap((item) => {
+    const conditions: Array<{ [field: string]: { $in?: string[]; $gte?: number; $lte?: number } }> =
+      [];
 
-async function buildQueryPack(query: string, rewrite: RewriteMode) {
-  if (rewrite === 'off' || (rewrite === 'auto' && !shouldAutoRewrite(query))) {
-    return {
-      semanticQuery: query,
-      fullTextQueries: [query],
-      rewriteApplied: false,
-    };
-  }
+    if (item.terms) {
+      for (const field in item.terms) {
+        conditions.push({
+          [field]: {
+            $in: item.terms[field],
+          },
+        });
+      }
+    }
 
-  const rewritten = await generateQuery(query);
-  return {
-    semanticQuery: rewritten.semantic_query,
-    fullTextQueries: buildLexicalQueryCandidates(rewritten),
-    rewriteApplied: true,
-  };
+    if (item.range) {
+      for (const field in item.range) {
+        const rangeConditions: { $gte?: number; $lte?: number } = {};
+        if (item.range[field].gte !== undefined) {
+          rangeConditions.$gte = item.range[field].gte;
+        }
+        if (item.range[field].lte !== undefined) {
+          rangeConditions.$lte = item.range[field].lte;
+        }
+        conditions.push({
+          [field]: rangeConditions,
+        });
+      }
+    }
+    return conditions;
+  });
+
+  return andConditions.length > 0
+    ? {
+        $and: andConditions,
+      }
+    : undefined;
 }
 
 function loadCourseSearchTarget(): SearchTarget {
@@ -602,25 +483,24 @@ async function retrieveChunks(
   fullTextQueries: string[],
   topK: number,
   extK: number,
-  filters: ReturnType<typeof normalizeFilters>,
+  filters: FiltersType,
 ) {
   const searchVector = await generateEmbedding(semanticQuery, {
     model: openai_embedding_model,
   });
 
-  const opensearchFilters = buildOpenSearchFilter(filters);
   const opensearchBody = {
     query: {
       bool: {
         should: fullTextQueries.map((query) => ({ match: { text: query } })),
         minimum_should_match: 1,
-        ...(opensearchFilters.length > 0 ? { filter: opensearchFilters } : {}),
+        ...(filters.length > 0 ? { filter: filters } : {}),
       },
     },
     size: topK,
   };
 
-  const pineconeFilter = buildPineconeFilter(filters);
+  const pineconeFilter = filterToPCQuery(filters);
   const pineconeIndex = pc.index(target.pineconeIndexName);
 
   const [pineconeResponse, fulltextResponse] = await Promise.all([
@@ -789,150 +669,6 @@ function toCourseDocuments(chunks: ReturnType<typeof toResponseChunk>[]) {
   return documents;
 }
 
-async function synthesizeAnswer(query: string, chunks: ReturnType<typeof toResponseChunk>[]) {
-  if (chunks.length === 0) {
-    return {
-      answer: 'I do not have enough authorized course material to answer this question.',
-      citations: [],
-    };
-  }
-
-  const client = getOpenAIClient(Deno.env.get('OPENAI_BASE_URL') || undefined) as unknown as {
-    responses?: { create?: (args: unknown) => Promise<unknown> };
-    chat?: { completions?: { create?: (args: unknown) => Promise<unknown> } };
-  };
-  const model = Deno.env.get('OPENAI_CHAT_MODEL') || 'gpt-4o-mini';
-  const context = chunks
-    .slice(0, 8)
-    .map(
-      (chunk, index) =>
-        `[${index + 1}] document_id=${chunk.document_id} chunk=${chunk.chunk_index}\n${chunk.text}`,
-    )
-    .join('\n\n');
-
-  const systemPrompt =
-    'Answer using only the provided authorized course context. If the context is insufficient, say that you do not have enough evidence. Include bracketed citation numbers for factual claims.';
-  const userPrompt = `Question:\n${query}\n\nAuthorized course context:\n${context}`;
-
-  let rawResponse: unknown;
-  if (client.responses?.create) {
-    rawResponse = await client.responses.create({
-      model,
-      input: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-    });
-  } else if (client.chat?.completions?.create) {
-    rawResponse = await client.chat.completions.create({
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-    });
-  } else {
-    throw new Error('OpenAI SDK missing both responses.create and chat.completions.create');
-  }
-
-  const answer = extractOpenAIText(rawResponse);
-
-  return {
-    answer: answer || 'I do not have enough authorized course material to answer this question.',
-    citations: chunks.slice(0, 8).map((chunk, index) => ({
-      citation_id: index + 1,
-      record_id: chunk.record_id,
-      document_id: chunk.document_id,
-      chunk_index: chunk.chunk_index,
-    })),
-  };
-}
-
-function extractOpenAIText(response: unknown): string {
-  if (!response || typeof response !== 'object') {
-    return '';
-  }
-
-  const record = response as Record<string, unknown>;
-  if (typeof record.output_text === 'string') {
-    return record.output_text.trim();
-  }
-
-  const output = record.output;
-  if (Array.isArray(output)) {
-    for (const item of output) {
-      const content =
-        item && typeof item === 'object' ? (item as Record<string, unknown>).content : null;
-      if (!Array.isArray(content)) {
-        continue;
-      }
-      for (const part of content) {
-        if (
-          part &&
-          typeof part === 'object' &&
-          typeof (part as Record<string, unknown>).text === 'string'
-        ) {
-          return String((part as Record<string, unknown>).text).trim();
-        }
-      }
-    }
-  }
-
-  const choices = record.choices;
-  if (Array.isArray(choices)) {
-    for (const choice of choices) {
-      const message =
-        choice && typeof choice === 'object' ? (choice as Record<string, unknown>).message : null;
-      if (message && typeof message === 'object') {
-        const content = (message as Record<string, unknown>).content;
-        if (typeof content === 'string') {
-          return content.trim();
-        }
-      }
-    }
-  }
-
-  return '';
-}
-
-async function insertQueryLog(input: {
-  actorId: string;
-  scope: Record<string, unknown>;
-  mode: QueryMode;
-  rewrite: RewriteMode;
-  rewriteApplied: boolean;
-  originalQuery: string;
-  semanticQuery: string;
-  fullTextQueries: string[];
-  filters: Record<string, unknown>;
-  topK: number;
-  extK: number;
-  resultCount: number;
-  latencyMs: number;
-}) {
-  const { error } = await getServiceSupabase()
-    .from('kb_query_logs')
-    .insert({
-      actor_id: input.actorId,
-      scope_json: input.scope,
-      mode: input.mode,
-      rewrite_mode: input.rewrite,
-      rewrite_applied: input.rewriteApplied,
-      original_query: input.originalQuery,
-      semantic_query: input.semanticQuery,
-      full_text_query: input.fullTextQueries.join('\n'),
-      filters_json: input.filters,
-      top_k: input.topK,
-      ext_k: input.extK > 0 ? input.extK : null,
-      result_count: input.resultCount,
-      latency_ms: input.latencyMs,
-    });
-
-  if (error) {
-    console.error('Failed to insert kb_query_logs row:', error.message);
-  }
-}
-
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -959,8 +695,6 @@ Deno.serve(async (req) => {
       return auth;
     }
 
-    const startedAt = Date.now();
-    const documentScopeIds = normalizeUuidList(body.scope.document_ids, 'scope.document_ids');
     const target = loadCourseSearchTarget();
 
     if (!target.opensearchIndexName || !target.pineconeIndexName || !target.pineconeNamespace) {
@@ -973,64 +707,28 @@ Deno.serve(async (req) => {
       );
     }
 
-    const filters = normalizeFilters(
-      mergeScopeIntoFilters(body.filters, body.scope, auth.collectionScope),
-    );
-    const queryPack = await buildQueryPack(body.query, body.rewrite);
+    const filter = { ...body.filter };
+    const scopeTags = auth.collectionScope.map(collectionPathToTag).filter(Boolean);
+    if (scopeTags.length > 0) {
+      filter.tags = [...normalizeStringList(filter.tags), ...scopeTags];
+    }
+    const filters = buildFilters(filter, body.datefilter);
+    const rewritten = await generateQuery(body.query);
     const retrievedChunks = await retrieveChunks(
       target,
-      queryPack.semanticQuery,
-      queryPack.fullTextQueries,
+      rewritten.semantic_query,
+      buildLexicalQueryCandidates(rewritten),
       body.topK,
       body.extK,
       filters,
     );
 
-    const scopedDocumentIds = new Set(documentScopeIds);
-    const chunks = retrievedChunks
-      .filter((chunk) => scopedDocumentIds.size === 0 || scopedDocumentIds.has(chunk.document_id))
-      .map(toResponseChunk);
-
+    const chunks = retrievedChunks.map(toResponseChunk);
     const courseDocuments = toCourseDocuments(chunks);
-    const answerResult =
-      body.mode === 'answer'
-        ? await synthesizeAnswer(body.query, chunks)
-        : { answer: null, citations: [] };
-    const latencyMs = Date.now() - startedAt;
 
-    await insertQueryLog({
-      actorId: auth.actorId,
-      scope: body.scope,
-      mode: body.mode,
-      rewrite: body.rewrite,
-      rewriteApplied: queryPack.rewriteApplied,
-      originalQuery: body.query,
-      semanticQuery: queryPack.semanticQuery,
-      fullTextQueries: queryPack.fullTextQueries,
-      filters: body.filters,
-      topK: body.topK,
-      extK: body.extK,
-      resultCount: courseDocuments.length,
-      latencyMs,
-    });
     logInsert(auth.subject, Date.now(), 'course_search', body.topK, body.extK);
 
-    if (body.mode === 'retrieve') {
-      return jsonResponse(courseDocuments);
-    }
-
-    const queryId = crypto.randomUUID();
-    return jsonResponse({
-      query_id: queryId,
-      mode: body.mode,
-      rewrite: body.rewrite,
-      rewrite_applied: queryPack.rewriteApplied,
-      answer: answerResult.answer,
-      citations: answerResult.citations,
-      chunks,
-      result_count: chunks.length,
-      latency_ms: latencyMs,
-    });
+    return jsonResponse(courseDocuments);
   } catch (error) {
     if (error instanceof RequestValidationError) {
       return jsonResponse({ error: error.message }, { status: 400 });

--- a/test.example.http
+++ b/test.example.http
@@ -272,25 +272,32 @@ curl -i --location --request POST '{{$dotenv REMOTE_ENDPOINT}}/edu_search' \
 ============================================================
 Course
 ============================================================
-### @name course：local,retrieve,email-password
+### @name course：local，没有filter
 curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/course_search' \
     --header 'Content-Type: application/json' \
     --header 'email: {{$dotenv EMAIL}}' \
     --header 'password: {{$dotenv PASSWORD}}' \
-    --data '{"query":"这门课程如何讨论知识组织？", "mode":"retrieve", "rewrite":"auto", "scope":{"collection_path":"/course/thu_humanities"}, "topK":5, "extK":1}'
+    --data '{"query":"这门课程如何讨论知识组织？", "topK":5, "extK":1}'
 
-### @name course：local,retrieve,bearer
+### @name course：local，tag_filter
 curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/course_search' \
     --header 'Content-Type: application/json' \
-    --header 'Authorization: Bearer {{$dotenv REMOTE_BEARER_TOKEN}}' \
-    --data '{"query":"这门课程如何讨论知识组织？", "mode":"retrieve", "rewrite":"auto", "scope":{"collection_path":"/course/thu_humanities"}, "filters":{"tags":["thu_humanities"]}, "topK":5, "extK":1}'
+    --header 'email: {{$dotenv EMAIL}}' \
+    --header 'password: {{$dotenv PASSWORD}}' \
+    --data '{"query":"这门课程如何讨论知识组织？", "filter":{"tags":["thu_humanities"]}, "topK":5, "extK":1}'
 
-### @name course：remote,answer,bearer
+### @name course：local，tag_filter,x-api-key
+curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/course_search' \
+    --header 'Content-Type: application/json' \
+    --header 'x-api-key: {{$dotenv X_API_KEY}}' \
+    --data '{"query":"这门课程如何讨论知识组织？", "filter":{"tags":["thu_humanities"]}, "topK":5, "extK":1}'
+
+### @name course：remote,tag_filter,bearer
 curl -i --location --request POST '{{$dotenv REMOTE_ENDPOINT}}/course_search' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer {{$dotenv REMOTE_BEARER_TOKEN}}' \
     --header 'x-region: {{$dotenv X_REGION}}' \
-    --data '{"query":"这门课程如何讨论知识组织？", "mode":"answer", "rewrite":"auto", "scope":{"collection_path":"/course/thu_humanities"}, "topK":5, "extK":1}'
+    --data '{"query":"这门课程如何讨论知识组织？", "filter":{"tags":["thu_humanities"]}, "topK":5, "extK":1}'
 
 
 ============================================================


### PR DESCRIPTION
Review requested: li-nan@tsinghua.edu.cn / @linancn

## Summary
- Align `course_search` retrieve behavior with `sci_search`: query/filter/datefilter/topK/extK input, fixed query rewrite, hybrid retrieval, and `[{ content, source }]` response shape.
- Remove extra course_search-only request surface such as `mode`, `rewrite`, answer generation, scope/document id filtering, broad service-role env aliases, and hard-coded course index names.
- Add a non-production query rewrite model evaluation script and supporting docs/shared OpenAI structured-task model override wiring.

## Validation
- `deno check --config supabase/functions/deno.json scripts/eval_query_rewrite_models.ts scripts/eval_search_quality.ts supabase/functions/_shared/openai_structured.ts supabase/functions/_shared/openai_structured_task.ts supabase/functions/course_search/index.ts`
- `deno lint --config supabase/functions/deno.json scripts/eval_query_rewrite_models.ts scripts/eval_search_quality.ts supabase/functions/_shared/openai_structured.ts supabase/functions/_shared/openai_structured_task.ts supabase/functions/course_search/index.ts`
- `npx prettier -c AGENTS.md README.md _docs/README.md _docs/architecture/repo-architecture.md _docs/contracts/repo-contract.md _docs/runbooks/development.md _docs/standards/documentation-standards.md scripts/eval_query_rewrite_models.ts scripts/eval_search_quality.ts supabase/functions/_shared/openai_structured.ts supabase/functions/_shared/openai_structured_task.ts supabase/functions/course_search/index.ts .docpact/config.yaml`
- `git diff --check`
- `docpact lint --root . --files ...`
- Local `course_search` smoke test returned HTTP 200 with `[{ content, source }]`.
- Query rewrite smoke for `gpt-5.4-nano` passed 5/5 with 100% JSON/schema validity.